### PR TITLE
Make the package more universal

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { compose } from 'mantra-core';
+import { compose } from 'react-komposer';
 
 export function composeReduxBase(fn, props, onData) {
   const { Store } = props.context();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,12 @@
 import { compose } from 'react-komposer';
 
 export function composeReduxBase(fn, props, onData) {
-  const { Store } = props.context();
+  const context = props.context();
+  const Store = context.Store || context.store;
+
+  if (!Store) {
+    throw new Error('No store found in the context');
+  }
 
   const processState = () => {
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,12 @@
 import { compose } from 'react-komposer';
 
 export function composeReduxBase(fn, props, onData) {
-  const context = props.context();
+  if (!props.context) {
+    throw new Error('No context passed as prop.');
+  }
+
+  const context = typeof props.context === 'function' ? props.context() : props.context;
+
   const Store = context.Store || context.store;
 
   if (!Store) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-komposer-redux",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/sammkj/react-komposer-redux",
   "repository": {
     "type": "git",
@@ -32,6 +32,6 @@
     "eslint-plugin-react": "^5.1.1"
   },
   "peerDependencies": {
-    "mantra-core": "1.6.1"
+    "react-komposer": "^1.8.0"
   }
 }


### PR DESCRIPTION
Hey, thanks for a nice package. I use `react-komposer` but not mantra. When I wanted to use your package I ran into some problems:

1) We don't need to depend on `mantra-core`. The `compose` method comes from `react-komposer` (on which mantra depends itself) so I added this as peer dependency. This way and app that doesn't use mantra doesn't need to install the whole `mantra-core` package just to use this function.

2) My store in the context isn't named `Store` but `store`. I added support for both possibilities and a helpful error.

3) Also, I like passing my context as a object, not a function so again, I added support for both possibilities.

What do you think about this changes? Cheers!
